### PR TITLE
Add Utterson

### DIFF
--- a/config/jekyllrb.com.yaml
+++ b/config/jekyllrb.com.yaml
@@ -36,6 +36,9 @@ talk:
 teams:
   - type: CNAME
     value: teams.jekyllrb.com.herokudns.com
+utterson:
+  - type: CNAME
+    value: d34iuq4h6fd9zb.cloudfront.net
 www:
   - type: CNAME
     value: jekyll.github.io


### PR DESCRIPTION
If we want to do this, we will also need to add `utterson.jekyllrb.com` to the SSL certificate and make some configuration changes on the AWS side, but I wanted to open this PR to start the conversation.

I'm not sure that it makes sense for Utterson to be tied to `utterson.pathawks.com` instead of `jekyllrb.com`

Is this something we would be interested in doing?