### PR TITLE
Use bash executable consistently

### DIFF
--- a/script/apply
+++ b/script/apply
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -ex
 script/validate
 script/test

--- a/script/dump
+++ b/script/dump
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/script/list-domains
+++ b/script/list-domains
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . script/provider-credentials
 

--- a/script/provider-credentials
+++ b/script/provider-credentials
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 ZONES=""
 ZONES="${ZONES} jekyllrb.com"

--- a/script/test
+++ b/script/test
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/script/validate
+++ b/script/validate
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 


### PR DESCRIPTION
`#!/bin/bash` should always be used over `#!/bin/sh`, some reasons provided [here](https://askubuntu.com/questions/141928/what-is-the-difference-between-bin-sh-and-bin-bash).

Note: this should be tested on OS X aswell (which I assume some maintainers do have), since I don't know how this works on it.